### PR TITLE
Fix comment typo in server/vite.ts

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -52,7 +52,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- fix minor typo in server/vite.ts comment

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*