### PR TITLE
Fix chat title generation

### DIFF
--- a/client/src/components/chat/chat-history.tsx
+++ b/client/src/components/chat/chat-history.tsx
@@ -4,6 +4,7 @@ import { PlusIcon, X, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { Chat } from "@shared/schema";
+import { DEFAULT_CHAT_TITLE } from "@shared/constants";
 import { useMobile } from "@/hooks/use-mobile";
 import { useChat } from "@/hooks/use-chat";
 
@@ -87,7 +88,7 @@ export function ChatHistory({ className }: ChatHistoryProps) {
               className="w-full bg-primary text-white hover:bg-primary/90"
             >
               <PlusIcon className="h-5 w-5 mr-2" />
-              New Workflow
+              {DEFAULT_CHAT_TITLE}
             </Button>
           </div>
 
@@ -106,7 +107,7 @@ export function ChatHistory({ className }: ChatHistoryProps) {
                 <div className="flex items-start justify-between">
                   <div className="overflow-hidden">
                     <h3 className="text-sm font-medium text-foreground truncate max-w-[180px]">
-                      {chat.title || "New Workflow"}
+                      {chat.title || DEFAULT_CHAT_TITLE}
                     </h3>
                     <p className="text-xs text-muted-foreground mt-1">
                       {formatChatDate(chat.created_at)}
@@ -158,7 +159,7 @@ export function ChatHistory({ className }: ChatHistoryProps) {
           className="w-full"
         >
           <PlusIcon className="h-5 w-5 mr-2" />
-          New Workflow
+          {DEFAULT_CHAT_TITLE}
         </Button>
       </div>
 
@@ -177,7 +178,7 @@ export function ChatHistory({ className }: ChatHistoryProps) {
             <div className="flex items-start justify-between">
               <div className="overflow-hidden">
                 <h3 className="text-sm font-medium text-foreground truncate max-w-[180px]">
-                  {chat.title || "New Workflow"}
+                  {chat.title || DEFAULT_CHAT_TITLE}
                 </h3>
                 <p className="text-xs text-muted-foreground mt-1">
                   {formatChatDate(chat.created_at)}

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -9,6 +9,7 @@ import { Loader2 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { useChat } from "@/hooks/use-chat";
 import { Button } from "@/components/ui/button";
+import { DEFAULT_CHAT_TITLE } from "@shared/constants";
 
 export default function ChatPage() {
   const { user, isLoading: authLoading } = useAuth();
@@ -105,7 +106,7 @@ export default function ChatPage() {
               <div className="bg-white p-4 border-b border-gray-200">
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-medium text-gray-900">
-                    {activeChat.title || "New Workflow"}
+                    {activeChat.title || DEFAULT_CHAT_TITLE}
                   </h2>
                   <div className="flex space-x-2">
                     <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800">
@@ -217,7 +218,7 @@ export default function ChatPage() {
                   onClick={handleNewChat}
                   className="bg-primary-600 hover:bg-primary-700"
                 >
-                  Start New Workflow
+                  Start {DEFAULT_CHAT_TITLE}
                 </Button>
               </div>
             </div>

--- a/server/claude.ts
+++ b/server/claude.ts
@@ -6,6 +6,7 @@ import {
   Tool
 } from '@anthropic-ai/sdk/resources';
 import { storage } from './storage';
+import { DEFAULT_CHAT_TITLE } from '@shared/constants';
 import { WebSearch } from './websearch';
 
 // The newest Anthropic model is "claude-3-7-sonnet-20250219" which was released February 24, 2025
@@ -257,7 +258,7 @@ Now, based on the \`Opportunity Description\` you will receive, generate the imp
       const userMessages = messages.filter(m => m.role === 'user').slice(0, 3);
       
       if (userMessages.length === 0) {
-        return 'New Workflow';
+        return DEFAULT_CHAT_TITLE;
       }
       
       const content = userMessages.map(m => m.content).join('\n');
@@ -275,7 +276,7 @@ Now, based on the \`Opportunity Description\` you will receive, generate the imp
       });
       
       // Extract title from response safely
-      let title = 'New Workflow';
+      let title = DEFAULT_CHAT_TITLE;
       
       // Make sure response has content blocks
       if (response.content && response.content.length > 0) {
@@ -291,16 +292,16 @@ Now, based on the \`Opportunity Description\` you will receive, generate the imp
       // Make sure title is reasonable
       if (title.length < 3 || title.length > 60) {
         console.log(`Title length ${title.length} outside acceptable range, using default`);
-        title = 'New Workflow';
+        title = DEFAULT_CHAT_TITLE;
       }
       
       // Update the chat title in database
       await storage.updateChatTitle(chatId, title);
-      
+
       return title;
     } catch (error) {
       console.error('Error generating chat title:', error);
-      return 'New Workflow';
+      return DEFAULT_CHAT_TITLE;
     }
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { Claude } from "./claude";
 import { DebugTools } from "./debug";
+import { DEFAULT_CHAT_TITLE } from "@shared/constants";
 import { z } from "zod";
 import { loginSchema } from "@shared/schema";
 
@@ -144,7 +145,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const messages = await storage.getMessagesByChatId(chatId);
         const userMessages = messages.filter(m => m.role === 'user');
         
-        if (userMessages.length >= 3 && !chat.title) {
+        if (
+          userMessages.length >= 3 &&
+          (!chat.title || chat.title === DEFAULT_CHAT_TITLE)
+        ) {
           // Generate and update the title (wait for it to complete)
           try {
             console.log(`Generating title for chat ${chatId} after ${userMessages.length} user messages`);
@@ -153,7 +157,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             
             // Get updated chat with new title
             const updatedChat = await storage.getChatById(chatId);
-            if (updatedChat && updatedChat.title !== 'New Workflow') {
+            if (updatedChat && updatedChat.title !== DEFAULT_CHAT_TITLE) {
               console.log(`Successfully updated chat title to "${updatedChat.title}"`);
             } else {
               console.warn(`Failed to update chat title, still using default or unchanged`);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12,6 +12,7 @@ import {
 } from '@shared/schema';
 import { eq, and, desc, asc } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
+import { DEFAULT_CHAT_TITLE } from '@shared/constants';
 
 // User operations
 export const storage = {
@@ -114,7 +115,7 @@ export const storage = {
       const [chat] = await db.insert(chats).values({
         id: chatId,
         user_id: userId,
-        title: 'New Workflow'
+        title: DEFAULT_CHAT_TITLE
       }).returning();
       return chat;
     } catch (error) {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_CHAT_TITLE = 'New Workflow';


### PR DESCRIPTION
## Summary
- define `DEFAULT_CHAT_TITLE` constant
- use default title when creating chats
- fix title generation condition so default gets replaced
- replace hardcoded strings in client

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*