### PR TITLE
Fix comment for Claude reasoning tokens

### DIFF
--- a/server/claude.ts
+++ b/server/claude.ts
@@ -610,9 +610,9 @@ Now, based on the \`Opportunity Description\` you will receive, generate the imp
         messages: [{ role: 'user', content: initialPrompt }],
         tools,
         tool_choice: { type: "auto" },
-        thinking: { 
+        thinking: {
           type: 'enabled',
-          budget_tokens: 10000 // Allocate 2000 tokens for Claude's internal reasoning
+          budget_tokens: 10000 // Allocate 10000 tokens for Claude's internal reasoning
         }
       });
       


### PR DESCRIPTION
## Summary
- correct comment for thinking token budget in `server/claude.ts`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*