### PR TITLE
Add vitest testing setup and basic workflow JSON tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push --force --config=./drizzle.config.ts",
-    "db:seed": "tsx db/seed.ts"
+    "db:seed": "tsx db/seed.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",
@@ -100,7 +101,8 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.9"
+    "vite": "^5.4.9",
+    "vitest": "^1.5.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/tests/claude.test.ts
+++ b/tests/claude.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { Claude } from '../server/claude';
+
+const validate = (Claude as any).validateWorkflowJson as (json: any) => boolean;
+
+describe('validateWorkflowJson', () => {
+  it('returns true for valid workflow JSON', () => {
+    const valid = {
+      title: 'Workflow',
+      start_event: 'start',
+      end_event: 'end',
+      steps: [],
+      people: [],
+      systems: [],
+      pain_points: []
+    };
+    expect(validate(valid)).toBe(true);
+  });
+
+  it('returns false when required field is missing', () => {
+    const missing = {
+      start_event: 'start',
+      end_event: 'end',
+      steps: [],
+      people: [],
+      systems: [],
+      pain_points: []
+    };
+    expect(validate(missing)).toBe(false);
+  });
+
+  it('returns false when field types are incorrect', () => {
+    const wrongType = {
+      title: 'Workflow',
+      start_event: 'start',
+      end_event: 'end',
+      steps: {},
+      people: [],
+      systems: [],
+      pain_points: []
+    } as any;
+    expect(validate(wrongType)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- install Vitest dev dependency and add a test script
- add Vitest configuration
- create tests for `validateWorkflowJson`

## Testing
- `npm test` *(fails: `vitest: not found`)*