### PR TITLE
Update chat title condition

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { Claude } from "./claude";
 import { DebugTools } from "./debug";
+import { DEFAULT_CHAT_TITLE } from "@shared/constants";
 import { z } from "zod";
 import { loginSchema } from "@shared/schema";
 
@@ -144,7 +145,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const messages = await storage.getMessagesByChatId(chatId);
         const userMessages = messages.filter(m => m.role === 'user');
         
-        if (userMessages.length >= 3 && !chat.title) {
+        if (userMessages.length >= 3 && chat.title === DEFAULT_CHAT_TITLE) {
           // Generate and update the title (wait for it to complete)
           try {
             console.log(`Generating title for chat ${chatId} after ${userMessages.length} user messages`);
@@ -153,7 +154,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             
             // Get updated chat with new title
             const updatedChat = await storage.getChatById(chatId);
-            if (updatedChat && updatedChat.title !== 'New Workflow') {
+            if (updatedChat && updatedChat.title !== DEFAULT_CHAT_TITLE) {
               console.log(`Successfully updated chat title to "${updatedChat.title}"`);
             } else {
               console.warn(`Failed to update chat title, still using default or unchanged`);


### PR DESCRIPTION
## Summary
- update chat title assignment condition in `server/routes.ts`
- use `DEFAULT_CHAT_TITLE` constant to avoid merge conflicts

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*